### PR TITLE
Update screenshots script to easily work on any computer

### DIFF
--- a/screenshots/01_takeScreenshots.sh
+++ b/screenshots/01_takeScreenshots.sh
@@ -3,8 +3,8 @@ set -e
 
 cleanup() {
     adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill && sleep 5; done
-    export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
-    $ANDROID_HOME/tools/bin/avdmanager delete avd -n "AntennaPodScreenshots" || true
+    export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+    $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager delete avd -n "AntennaPodScreenshots" || true
     rm nohup.out || true
 }
 trap cleanup INT TERM
@@ -15,7 +15,7 @@ function setupEmulator() {
     emulatorConfig=$1
     export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
     cleanup
-    echo no | $ANDROID_HOME/tools/bin/avdmanager create avd --force --name "AntennaPodScreenshots" --abi google_apis/x86_64 --package 'system-images;android-31;google_apis;x86_64'
+    echo no | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --force --name "AntennaPodScreenshots" --abi google_apis/x86_64 --package 'system-images;android-36;google_apis;x86_64'
     echo "
 disk.dataPartition.size=6G
 hw.battery=yes
@@ -50,7 +50,7 @@ function install() {
 function resetDatabase() {
     theme=$1
     adb shell am force-stop de.danoeh.antennapod.debug
-    adb shell rm /data/data/de.danoeh.antennapod.debug/databases/Antennapod.db-journal
+    # adb shell rm /data/data/de.danoeh.antennapod.debug/databases/Antennapod.db-journal
     adb push app/src/play/play/screenshots/ScreenshotsDatabaseExport.db /data/data/de.danoeh.antennapod.debug/databases/Antennapod.db
     adb shell chmod 777 /data/data/de.danoeh.antennapod.debug/databases
     adb shell chmod 777 /data/data/de.danoeh.antennapod.debug/databases/Antennapod.db

--- a/screenshots/01_takeScreenshots.sh
+++ b/screenshots/01_takeScreenshots.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -e
 
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+
 cleanup() {
     adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill && sleep 5; done
-    export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
     $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager delete avd -n "AntennaPodScreenshots" || true
     rm nohup.out || true
 }
@@ -13,7 +14,6 @@ trap cleanup INT TERM
 
 function setupEmulator() {
     emulatorConfig=$1
-    export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
     cleanup
     echo no | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --force --name "AntennaPodScreenshots" --abi google_apis/x86_64 --package 'system-images;android-31;google_apis;x86_64'
     echo "
@@ -34,7 +34,6 @@ $emulatorConfig
 }
 
 function install() {
-    export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
     adb root
 
     adb uninstall de.danoeh.antennapod.debug || true
@@ -50,7 +49,7 @@ function install() {
 function resetDatabase() {
     theme=$1
     adb shell am force-stop de.danoeh.antennapod.debug
-    # adb shell rm /data/data/de.danoeh.antennapod.debug/databases/Antennapod.db-journal
+    adb shell rm /data/data/de.danoeh.antennapod.debug/databases/Antennapod.db-journal || true
     adb push app/src/play/play/screenshots/ScreenshotsDatabaseExport.db /data/data/de.danoeh.antennapod.debug/databases/Antennapod.db
     adb shell chmod 777 /data/data/de.danoeh.antennapod.debug/databases
     adb shell chmod 777 /data/data/de.danoeh.antennapod.debug/databases/Antennapod.db

--- a/screenshots/01_takeScreenshots.sh
+++ b/screenshots/01_takeScreenshots.sh
@@ -15,7 +15,7 @@ function setupEmulator() {
     emulatorConfig=$1
     export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
     cleanup
-    echo no | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --force --name "AntennaPodScreenshots" --abi google_apis/x86_64 --package 'system-images;android-36;google_apis;x86_64'
+    echo no | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --force --name "AntennaPodScreenshots" --abi google_apis/x86_64 --package 'system-images;android-31;google_apis;x86_64'
     echo "
 disk.dataPartition.size=6G
 hw.battery=yes

--- a/screenshots/01_takeScreenshots.sh
+++ b/screenshots/01_takeScreenshots.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
 cleanup() {
     adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill && sleep 5; done

--- a/screenshots/01_takeScreenshots.sh
+++ b/screenshots/01_takeScreenshots.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-
 cleanup() {
     adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill && sleep 5; done
     $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager delete avd -n "AntennaPodScreenshots" || true


### PR DESCRIPTION
I had to make a few modifications to this script in order for it to work in my machine:

- For me `avdmanger` and `emulator` are under `$ANDROID_HOME/cmdline-tools/latest/bin/`, as I installed them from Android Studio directly, and supposing that `ANDROID_HOME=~/Android/Sdk`. I'm not sure if this is standard.
- ~I changed the emulator to use an image with api level 36, but this is only because that is what I had downloaded, so I don't think it is a needed change.~
- I changed java to java 17, as with java 8 it gave me an error (maybe I should check this back)